### PR TITLE
Raw cells

### DIFF
--- a/week00b-python-intro.ipynb
+++ b/week00b-python-intro.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 205,
    "metadata": {
     "collapsed": false
    },
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 206,
    "metadata": {
     "collapsed": false
    },
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 207,
    "metadata": {
     "collapsed": true
    },
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 208,
    "metadata": {
     "collapsed": false
    },
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 209,
    "metadata": {
     "collapsed": false
    },
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 210,
    "metadata": {
     "collapsed": false
    },
@@ -240,8 +240,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`i = input('give me information') \n",
-    "print(i)`"
+    "```python\n",
+    "i = input('give me information') \n",
+    "```"
    ]
   },
   {
@@ -268,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 211,
    "metadata": {
     "collapsed": false
    },
@@ -299,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 212,
    "metadata": {
     "collapsed": false
    },
@@ -328,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 213,
    "metadata": {
     "collapsed": false
    },
@@ -357,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 214,
    "metadata": {
     "collapsed": false
    },
@@ -386,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 215,
    "metadata": {
     "collapsed": false
    },
@@ -414,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 216,
    "metadata": {
     "collapsed": false
    },
@@ -454,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 217,
    "metadata": {
     "collapsed": false
    },
@@ -484,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 218,
    "metadata": {
     "collapsed": false
    },
@@ -522,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 219,
    "metadata": {
     "collapsed": false
    },
@@ -552,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 220,
    "metadata": {
     "collapsed": false
    },
@@ -581,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": 221,
    "metadata": {
     "collapsed": false
    },
@@ -611,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 222,
    "metadata": {
     "collapsed": false
    },
@@ -641,7 +642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 223,
    "metadata": {
     "collapsed": false
    },
@@ -668,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 224,
    "metadata": {
     "collapsed": false
    },
@@ -699,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 225,
    "metadata": {
     "collapsed": false
    },
@@ -749,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 226,
    "metadata": {
     "collapsed": false
    },
@@ -793,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 227,
    "metadata": {
     "collapsed": true
    },
@@ -813,7 +814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 228,
    "metadata": {
     "collapsed": false
    },
@@ -845,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 229,
    "metadata": {
     "collapsed": false
    },
@@ -875,7 +876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 230,
    "metadata": {
     "collapsed": false
    },
@@ -894,7 +895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": 231,
    "metadata": {
     "collapsed": false
    },

--- a/week00b-python-intro.ipynb
+++ b/week00b-python-intro.ipynb
@@ -223,7 +223,9 @@
    "metadata": {},
    "source": [
     "a = 16\n",
+    "\n",
     "a = a+2 \n",
+    "\n",
     "print(a)"
    ]
   },
@@ -241,6 +243,7 @@
    "metadata": {},
    "source": [
     "i = input('give me information')\n",
+    "\n",
     "print(i)"
    ]
   },

--- a/week00b-python-intro.ipynb
+++ b/week00b-python-intro.ipynb
@@ -203,10 +203,10 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "2& = 8"
+    "`2& = 8 `"
    ]
   },
   {
@@ -219,14 +219,12 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "a = 16\n",
-    "\n",
-    "a = a+2 \n",
-    "\n",
-    "print(a)"
+    "`a = 16 \n",
+    "a = a+2  \n",
+    "print(a) `"
    ]
   },
   {
@@ -239,12 +237,11 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "i = input('give me information')\n",
-    "\n",
-    "print(i)"
+    "`i = input('give me information') \n",
+    "print(i)`"
    ]
   },
   {

--- a/week00b-python-intro.ipynb
+++ b/week00b-python-intro.ipynb
@@ -46,13 +46,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "print('Hello, World!'\n",
+    "`print('Hello, World!'\n",
     "print('Hello, World!'))\n",
     "print('Hello, World!\")\n",
-    "print('Hello, World!)"
+    "print('Hello, World!)`"
    ]
   },
   {
@@ -870,7 +870,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Arrays behave differently from lists. For multiplication and addition _replicate_ lists, but act on each individual _element_ in an array."
+    "Arrays behave differently from lists. Multiplication and addition operatations _replicate_ lists, but these operations act on each individual _elements_ in an array."
    ]
   },
   {


### PR DESCRIPTION
Using markdown code blocks for unexecuted code, instead of raw cells (which Github converts to HTML)